### PR TITLE
Add logistic regression model + oversampling for recall

### DIFF
--- a/.ipynb_checkpoints/main-checkpoint.ipynb
+++ b/.ipynb_checkpoints/main-checkpoint.ipynb
@@ -1982,7 +1982,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can notice how this improves recall for the presence of heart disease from 10% to 78% with oversampling. However, with these improvements we do get a decrease in accuracy of the model from 92% to 75% as the model predicts more people to have heart disease as a whole, and prescision for prescence of heart disease going from 53% to 23%. As such, the model could be used to screen for people with a possible likelihood of having heart disease given only the 17 features that the model uses. This model classification could then support a pipeline of ruling out individuals for heart disease and collect futher health data for considering additional screening and diagnosis as a method lower strain on health systems."
+    "We can notice how this improves recall for the presence of heart disease from 10% to 78% with oversampling. However, with these improvements we do get a decrease in accuracy of the model from 92% to 75% as the model predicts more people to have heart disease as a whole, and prescision for prescence of heart disease going from 53% to 23%. As such, the model could be used to screen for people with a possible likelihood of having heart disease given only the 17 features that the model uses. This model classification could then support a pipeline of ruling out individuals for heart disease and collect futher health data for considering additional screening and diagnosis as a method to lower strain on health systems."
    ]
   },
   {

--- a/main.ipynb
+++ b/main.ipynb
@@ -1982,7 +1982,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can notice how this improves recall for the presence of heart disease from 10% to 78% with oversampling. However, with these improvements we do get a decrease in accuracy of the model from 92% to 75% as the model predicts more people to have heart disease as a whole, and prescision for prescence of heart disease going from 53% to 23%. As such, the model could be used to screen for people with a possible likelihood of having heart disease given only the 17 features that the model uses. This model classification could then support a pipeline of ruling out individuals for heart disease and collect futher health data for considering additional screening and diagnosis as a method lower strain on health systems."
+    "We can notice how this improves recall for the presence of heart disease from 10% to 78% with oversampling. However, with these improvements we do get a decrease in accuracy of the model from 92% to 75% as the model predicts more people to have heart disease as a whole, and prescision for prescence of heart disease going from 53% to 23%. As such, the model could be used to screen for people with a possible likelihood of having heart disease given only the 17 features that the model uses. This model classification could then support a pipeline of ruling out individuals for heart disease and collect futher health data for considering additional screening and diagnosis as a method to lower strain on health systems."
    ]
   },
   {


### PR DESCRIPTION
Everything after `Logistic Regression Model Comparison` of the notebook was added. Analyzed why the 92% accuracy of the first two models didn't tell the whole story of classification. Thus, oversampling was used to contrast the results from the first two models. Then looked at how the coefficients of the regression were contributing.